### PR TITLE
Feature/paginierung openui5 tabelle 62439

### DIFF
--- a/Template/Elements/ui5DataTable.php
+++ b/Template/Elements/ui5DataTable.php
@@ -296,6 +296,11 @@ JS;
 JS;
     }
 
+    /**
+     * Returns JavaScript-Functions which are necessary for the pagination.
+     *
+     * @return string
+     */
     protected function buildJsPagination()
     {
         $defaultPageSize = $this->getPaginationPageSize();


### PR DESCRIPTION
Paginierung mit Buttons funktioniert.

Der unübersichtliche Diff resultiert daraus, dass in der Orginaldatei der Großteil der Zeilenumbrüche Windows-Zeilenumbrüche, aber auch einige Unix-Zeilenumbrüche vorhanden sind. In der neuen Datei sind alles Unix-Zeilenumbrüche.
