### PR TITLE
FIX Infinite Scrolling funktioniert manchmal nicht

### DIFF
--- a/Template/Elements/ui5DataTable.php
+++ b/Template/Elements/ui5DataTable.php
@@ -362,8 +362,8 @@ JS;
         var oTable = {$this->getJsVar()};
         oTable.attachFirstVisibleRowChanged(function() {
             var pages = {$this->getId()}_pages;
-            if ((oTable.getFirstVisibleRow() + oTable.getVisibleRowCount() === pages.pageSize) &&
-                    (pages.end() + 1 !== pages.total)) {
+            var lastVisibleRow = oTable.getFirstVisibleRow() + oTable.getVisibleRowCount();
+            if ((pages.pageSize - lastVisibleRow <= 1) && (pages.end() + 1 !== pages.total)) {
                 pages.increasePageSize();
                 {$this->buildJsRefresh(true)}
             }


### PR DESCRIPTION
Infinite Scrolling funktionierte in Mozilla Firefox nicht richtig wenn die Tabelle 5, 9 oder 13 Zeilen hatte. Nach dem ersten Nachladen wird dann die letzte Zeile (die 60.) nicht angezeigt und deshalb auch nicht die darauffolgenden geladen. Dieser Fix repariert in diesem Fall das Infinite Scrolling.